### PR TITLE
Fixed bug, order of the 'or' matters

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -11569,8 +11569,8 @@
 									})),
 							A2(
 								_Bogdanp$elm_combine$Combine_Infix_ops['<|>'],
-								A2(_Bogdanp$elm_combine$Combine_Infix_ops['<|>'], _amilner42$kleen$TypescriptTypeParser$primitiveValueParser, _amilner42$kleen$TypescriptTypeParser$interfaceValueParser),
-								_amilner42$kleen$TypescriptTypeParser$referenceValueParser)),
+								A2(_Bogdanp$elm_combine$Combine_Infix_ops['<|>'], _amilner42$kleen$TypescriptTypeParser$referenceValueParser, _amilner42$kleen$TypescriptTypeParser$interfaceValueParser),
+								_amilner42$kleen$TypescriptTypeParser$primitiveValueParser)),
 						_Bogdanp$elm_combine$Combine$many(
 							A2(
 								_Bogdanp$elm_combine$Combine_Infix_ops['*>'],
@@ -11678,14 +11678,17 @@
 	var _amilner42$kleen$TypescriptTypeParser$typescriptTypeParser = _Bogdanp$elm_combine$Combine$rec(
 		function (_p37) {
 			var _p38 = _p37;
-			return _Bogdanp$elm_combine$Combine$many(
-				A2(
-					_Bogdanp$elm_combine$Combine_Infix_ops['<*'],
+			return A2(
+				_Bogdanp$elm_combine$Combine_Infix_ops['<*'],
+				_Bogdanp$elm_combine$Combine$many(
 					A2(
-						_Bogdanp$elm_combine$Combine_Infix_ops['*>'],
-						_amilner42$kleen$TypescriptTypeParser$whitespace,
-						A2(_Bogdanp$elm_combine$Combine_Infix_ops['<|>'], _amilner42$kleen$TypescriptTypeParser$interfaceParser, _amilner42$kleen$TypescriptTypeParser$typeParser)),
-					_amilner42$kleen$TypescriptTypeParser$whitespace));
+						_Bogdanp$elm_combine$Combine_Infix_ops['<*'],
+						A2(
+							_Bogdanp$elm_combine$Combine_Infix_ops['*>'],
+							_amilner42$kleen$TypescriptTypeParser$whitespace,
+							A2(_Bogdanp$elm_combine$Combine_Infix_ops['<|>'], _amilner42$kleen$TypescriptTypeParser$interfaceParser, _amilner42$kleen$TypescriptTypeParser$typeParser)),
+						_amilner42$kleen$TypescriptTypeParser$whitespace)),
+				_Bogdanp$elm_combine$Combine$end);
 		});
 	var _amilner42$kleen$TypescriptTypeParser$parseTypes = function (input) {
 		var _p39 = A2(_Bogdanp$elm_combine$Combine$parse, _amilner42$kleen$TypescriptTypeParser$typescriptTypeParser, input);

--- a/website/src/TypescriptTypeParser.elm
+++ b/website/src/TypescriptTypeParser.elm
@@ -12,6 +12,7 @@ import Combine
         , choice
         , fail
         , succeed
+        , end
         , optional
         , between
         , rec
@@ -211,9 +212,9 @@ typeValueParser =
                 <$> (sepBy1
                         (whitespace *> (string "|") <* whitespace)
                         ((succeed (,))
-                            <*> (primitiveValueParser
+                            <*> (referenceValueParser
                                     <|> interfaceValueParser
-                                    <|> referenceValueParser
+                                    <|> primitiveValueParser
                                 )
                             <*> (many (whitespace *> string "[]"))
                         )
@@ -327,10 +328,12 @@ typescriptTypeParser : Parser (List TypeStructure)
 typescriptTypeParser =
     rec
         (\() ->
-            many <|
+            (many <|
                 whitespace
                     *> (interfaceParser <|> typeParser)
                     <* whitespace
+            )
+                <* end
         )
 
 


### PR DESCRIPTION
Turns out the order of the `or` matters, it seems that the parser algo is greedy, and so it grabs the `number` even though that fails later. It may have to do with the `andThen` as well, because it only "grabbed it" because it parsed successfully there, so maybe if I chain them differently so it only succeeds if both succeed then that would work.

Added an `end` to make errors more clear (but this didn't fix bug as expected)
Closes #2