### PR TITLE
5 too verbose

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -11267,7 +11267,7 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('kindOfPrimitive: '),
+										_krisajenkins$formatting$Formatting$s('primitiveType: '),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
 											A2(_krisajenkins$formatting$Formatting$premap, primitiveTypeToString, _krisajenkins$formatting$Formatting$string),
@@ -11318,7 +11318,7 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('properties: {'),
+										_krisajenkins$formatting$Formatting$s('objectProperties: {'),
 										newLine)),
 								A2(
 									_krisajenkins$formatting$Formatting_ops['<>'],
@@ -11354,7 +11354,7 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('elementType: '),
+										_krisajenkins$formatting$Formatting$s('arrayElementType: '),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
 											A2(
@@ -11403,7 +11403,7 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('types: ['),
+										_krisajenkins$formatting$Formatting$s('unionTypes: ['),
 										newLine)),
 								A2(
 									_krisajenkins$formatting$Formatting_ops['<>'],

--- a/docs/app.js
+++ b/docs/app.js
@@ -11267,24 +11267,15 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('kindOfType: kleen.kindOfType.primitive,'),
-										newLine)),
-								A2(
-									_krisajenkins$formatting$Formatting_ops['<>'],
-									A2(
-										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent1,
+										_krisajenkins$formatting$Formatting$s('kindOfPrimitive: '),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											_krisajenkins$formatting$Formatting$s('kindOfPrimitive: '),
-											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												A2(_krisajenkins$formatting$Formatting$premap, primitiveTypeToString, _krisajenkins$formatting$Formatting$string),
-												newLine))),
-									A2(
-										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent0,
-										_krisajenkins$formatting$Formatting$s('}')))));
+											A2(_krisajenkins$formatting$Formatting$premap, primitiveTypeToString, _krisajenkins$formatting$Formatting$string),
+											newLine))),
+								A2(
+									_krisajenkins$formatting$Formatting_ops['<>'],
+									indent0,
+									_krisajenkins$formatting$Formatting$s('}'))));
 						return A2(_krisajenkins$formatting$Formatting$print, primitiveStructurePrinter, _p15._1);
 					case 'ObjectStructure':
 						var propertyToString = function (propertyTypeStructure) {
@@ -11327,36 +11318,27 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('kindOfType: kleen.kindOfType.object,'),
+										_krisajenkins$formatting$Formatting$s('properties: {'),
 										newLine)),
 								A2(
 									_krisajenkins$formatting$Formatting_ops['<>'],
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent1,
-										A2(
-											_krisajenkins$formatting$Formatting_ops['<>'],
-											_krisajenkins$formatting$Formatting$s('properties: {'),
-											newLine)),
+										A2(_krisajenkins$formatting$Formatting$premap, objectPropertiesToString, _krisajenkins$formatting$Formatting$string),
+										newLine),
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											A2(_krisajenkins$formatting$Formatting$premap, objectPropertiesToString, _krisajenkins$formatting$Formatting$string),
-											newLine),
+											indent1,
+											A2(
+												_krisajenkins$formatting$Formatting_ops['<>'],
+												_krisajenkins$formatting$Formatting$s('}'),
+												newLine)),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												indent1,
-												A2(
-													_krisajenkins$formatting$Formatting_ops['<>'],
-													_krisajenkins$formatting$Formatting$s('}'),
-													newLine)),
-											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												indent0,
-												_krisajenkins$formatting$Formatting$s('}')))))));
+											indent0,
+											_krisajenkins$formatting$Formatting$s('}'))))));
 						return A2(_krisajenkins$formatting$Formatting$print, objectStructurePrinter, _p15._1);
 					case 'ArrayStructure':
 						var arrayStructurePrinter = A2(
@@ -11372,27 +11354,18 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('kindOfType: kleen.kindOfType.array,'),
-										newLine)),
-								A2(
-									_krisajenkins$formatting$Formatting_ops['<>'],
-									A2(
-										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent1,
+										_krisajenkins$formatting$Formatting$s('elementType: '),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											_krisajenkins$formatting$Formatting$s('elementType: '),
 											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												A2(
-													_krisajenkins$formatting$Formatting$premap,
-													printStructure(tabLevel + 1),
-													_krisajenkins$formatting$Formatting$string),
-												newLine))),
-									A2(
-										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent0,
-										_krisajenkins$formatting$Formatting$s('}')))));
+												_krisajenkins$formatting$Formatting$premap,
+												printStructure(tabLevel + 1),
+												_krisajenkins$formatting$Formatting$string),
+											newLine))),
+								A2(
+									_krisajenkins$formatting$Formatting_ops['<>'],
+									indent0,
+									_krisajenkins$formatting$Formatting$s('}'))));
 						var typeStructure = A2(_amilner42$kleen$TypescriptTypeParser$nameAndContentToStructure, _p15._0, _p15._1);
 						return A2(_krisajenkins$formatting$Formatting$print, arrayStructurePrinter, typeStructure);
 					case 'UnionStructure':
@@ -11430,33 +11403,24 @@
 									indent1,
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										_krisajenkins$formatting$Formatting$s('kindOfType: kleen.kindOfType.union'),
+										_krisajenkins$formatting$Formatting$s('types: ['),
 										newLine)),
 								A2(
 									_krisajenkins$formatting$Formatting_ops['<>'],
+									A2(_krisajenkins$formatting$Formatting$premap, typeStructureContentsToString, _krisajenkins$formatting$Formatting$string),
 									A2(
 										_krisajenkins$formatting$Formatting_ops['<>'],
-										indent1,
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											_krisajenkins$formatting$Formatting$s('types: ['),
-											newLine)),
-									A2(
-										_krisajenkins$formatting$Formatting_ops['<>'],
-										A2(_krisajenkins$formatting$Formatting$premap, typeStructureContentsToString, _krisajenkins$formatting$Formatting$string),
+											indent1,
+											A2(
+												_krisajenkins$formatting$Formatting_ops['<>'],
+												_krisajenkins$formatting$Formatting$s(']'),
+												newLine)),
 										A2(
 											_krisajenkins$formatting$Formatting_ops['<>'],
-											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												indent1,
-												A2(
-													_krisajenkins$formatting$Formatting_ops['<>'],
-													_krisajenkins$formatting$Formatting$s(']'),
-													newLine)),
-											A2(
-												_krisajenkins$formatting$Formatting_ops['<>'],
-												indent0,
-												_krisajenkins$formatting$Formatting$s('}')))))));
+											indent0,
+											_krisajenkins$formatting$Formatting$s('}'))))));
 						return A2(_krisajenkins$formatting$Formatting$print, unionStructurePrinter, _p15._1);
 					default:
 						return A2(_elm_lang$core$Basics_ops['++'], _p15._1, referenceNamePostFix);

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,3 +1,3 @@
-import { typeStructure } from "./types";
+import { typeSchema } from "./types";
 export * from "./types";
-export declare const validModel: (typeStructure: typeStructure) => (any: any) => Promise<void>;
+export declare const validModel: (typeSchema: typeSchema) => (any: any) => Promise<void>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,10 +102,10 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
       // Figure out type of object. If the type is invalid, reject with a
       // `invalid schema` error, if you use typescript then these errors will
       // never occur.
-      const isObject = !isUndefined((typeSchema as objectSchema).properties);
-      const isArray = !isUndefined((typeSchema as arraySchema).elementType);
-      const isPrimitive = !isUndefined((typeSchema as primitiveSchema).kindOfPrimitive);
-      const isUnion = !isUndefined((typeSchema as unionSchema).types);
+      const isObject = !isUndefined((typeSchema as objectSchema).objectProperties);
+      const isArray = !isUndefined((typeSchema as arraySchema).arrayElementType);
+      const isPrimitive = !isUndefined((typeSchema as primitiveSchema).primitiveType);
+      const isUnion = !isUndefined((typeSchema as unionSchema).unionTypes);
 
       // To avoid boilerplate, we don't force the user to specify the
       // `kindOfTypeSchema` and instead manually resolve it at runtime.
@@ -140,7 +140,7 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
           // Cast for better inference.
           const primitiveStructure = typeSchema as primitiveSchema;
           const primitiveTypeStringName =
-            kindOfPrimitive[primitiveStructure.kindOfPrimitive];
+            kindOfPrimitive[primitiveStructure.primitiveType];
 
           if(typeof modelInstance === primitiveTypeStringName) {
             return resolveIfRestrictionMet(primitiveStructure.restriction);
@@ -162,7 +162,7 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
           } else {
             return Promise.all(
               modelInstance.map((arrayElement: any) => {
-                return validModel(arrayStructure.elementType)(arrayElement);
+                return validModel(arrayStructure.arrayElementType)(arrayElement);
               })
             )
             .then(() => {
@@ -186,7 +186,7 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
 
           // Unspecified properties on `modeInstance` not allowed.
           for(let modelProperty in modelInstance) {
-            if(!objectStructure.properties[modelProperty]) {
+            if(!objectStructure.objectProperties[modelProperty]) {
               return reject(
                 objectStructure.typeFailureError ||
                 schemaTypeError.objectHasExtraFields
@@ -195,8 +195,8 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
           }
 
           return Promise.all(
-            Object.keys(objectStructure.properties).map((key: string) => {
-              return validModel(objectStructure.properties[key])(modelInstance[key]);
+            Object.keys(objectStructure.objectProperties).map((key: string) => {
+              return validModel(objectStructure.objectProperties[key])(modelInstance[key]);
             })
           )
           .then(() => {
@@ -211,7 +211,7 @@ export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => 
           const unionStructure = typeSchema as unionSchema;
 
           return anyPromise(
-            unionStructure.types.map((singleTypeFromUnion: typeSchema) => {
+            unionStructure.unionTypes.map((singleTypeFromUnion: typeSchema) => {
               return validModel(singleTypeFromUnion)(modelInstance);
             })
           )

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,34 @@
 import {
-  kindOfType,
+  kindOfSchema,
   kindOfPrimitive,
-  typeStructure,
-  arrayStructure,
-  objectStructure,
-  unionStructure,
-  primitiveStructure,
+  typeSchema,
+  arraySchema,
+  objectSchema,
+  unionSchema,
+  primitiveSchema,
   restriction,
-  typeError
+  schemaTypeError
  } from "./types";
 import { isNull, isUndefined, anyPromise } from "./util";
 
 
 /**
  * Export types used in library so that a user can create their own
- * `typeStructures` (and have them be type checked).
+ * `typeSchema`s (and have them be type checked).
  */
 export * from "./types";
 
 
 /**
- * Asserts that a model has a valid structure.
+ * Asserts that a model is valid according to a schema.
  *
- * A valid structure means:
+ * A valid model means:
  *  - No extra properties are present anywhere in the model.
  *  - All neccessary properties are present.
  *  - Every property has the correct type
  *  - All restrictions are met for that property.
  *
- * @param typeStructure A representation of the valid type structure
+ * @param typeSchema A representation of a valid model.
  * @param modelInstance An instane of the model being validified
  * @returns Promise<void>, if the promise was `resolve`d, the model is valid,
  *          if the promise was `reject`ed, there was an error.
@@ -36,7 +36,7 @@ export * from "./types";
  * NOTE: The function is curried. This allows you to build your validifiers once
  *       and use them all over your code (keep it DRY).
  */
-export const validModel = (typeStructure: typeStructure): ((any) => Promise<void>) => {
+export const validModel = (typeSchema: typeSchema): ((any) => Promise<void>) => {
 
   return (modelInstance: any): Promise<void> => {
 
@@ -77,34 +77,68 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
       // Check for null/undefined, this doesn't depend on the `kindOfType`.
       {
         if(isNull(modelInstance)) {
-          if(typeStructure.nullAllowed) {
+          if(typeSchema.nullAllowed) {
             return resolve();
           }
 
           return reject(
-            typeStructure.customErrorOnTypeFailure ||
-            typeError.nullField
+            typeSchema.typeFailureError ||
+            schemaTypeError.nullField
           );
         }
 
         if(isUndefined(modelInstance)) {
-          if(typeStructure.undefinedAllowed) {
+          if(typeSchema.undefinedAllowed) {
             return resolve();
           }
 
           return reject(
-            typeStructure.customErrorOnTypeFailure ||
-            typeError.undefinedField
+            typeSchema.typeFailureError ||
+            schemaTypeError.undefinedField
           );
         }
       }
 
-      // Handle 4 cases depending on the `kindOfType`.
-      switch(typeStructure.kindOfType) {
+      // Figure out type of object. If the type is invalid, reject with a
+      // `invalid schema` error, if you use typescript then these errors will
+      // never occur.
+      const isObject = !isUndefined((typeSchema as objectSchema).properties);
+      const isArray = !isUndefined((typeSchema as arraySchema).elementType);
+      const isPrimitive = !isUndefined((typeSchema as primitiveSchema).kindOfPrimitive);
+      const isUnion = !isUndefined((typeSchema as unionSchema).types);
 
-        case kindOfType.primitive:
+      // To avoid boilerplate, we don't force the user to specify the
+      // `kindOfTypeSchema` and instead manually resolve it at runtime.
+      const kindOfTypeSchema =
+        (isObject && !isArray && !isPrimitive && !isUnion)
+          ?
+            kindOfSchema.object
+          :
+            (!isObject && isArray && !isPrimitive && !isUnion)
+              ?
+                kindOfSchema.array
+              :
+                (!isObject && !isArray && isPrimitive && !isUnion)
+                  ?
+                    kindOfSchema.primitive
+                  :
+                    (!isObject && !isArray && !isPrimitive && isUnion)
+                      ?
+                        kindOfSchema.union
+                      :
+                          undefined;
+
+      // If it's not a valid schema, we throw an `invalidSchema` error.
+      if(isUndefined(kindOfTypeSchema)) {
+        return Promise.reject(schemaTypeError.invalidSchema);
+      };
+
+      // Handle 4 cases depending on the `kindOfSchema`.
+      switch(kindOfTypeSchema) {
+
+        case kindOfSchema.primitive:
           // Cast for better inference.
-          const primitiveStructure = typeStructure as primitiveStructure;
+          const primitiveStructure = typeSchema as primitiveSchema;
           const primitiveTypeStringName =
             kindOfPrimitive[primitiveStructure.kindOfPrimitive];
 
@@ -113,17 +147,17 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
           }
 
           return reject(
-            primitiveStructure.customErrorOnTypeFailure ||
-            typeError.primitiveFieldInvalid
+            primitiveStructure.typeFailureError ||
+            schemaTypeError.primitiveFieldInvalid
           );
 
-        case kindOfType.array:
+        case kindOfSchema.array:
           // Casting for better inference.
-          const arrayStructure = typeStructure as arrayStructure;
+          const arrayStructure = typeSchema as arraySchema;
           if(!Array.isArray(modelInstance)) {
             return reject(
-              arrayStructure.customErrorOnTypeFailure ||
-              typeError.arrayFieldInvalid
+              arrayStructure.typeFailureError ||
+              schemaTypeError.arrayFieldInvalid
             );
           } else {
             return Promise.all(
@@ -139,14 +173,14 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
             });
           }
 
-        case kindOfType.object:
+        case kindOfSchema.object:
           // Casting for better inference.
-          const objectStructure = typeStructure as objectStructure;
+          const objectStructure = typeSchema as objectSchema;
 
           if(typeof modelInstance != "object") {
             return reject(
-              objectStructure.customErrorOnTypeFailure ||
-              typeError.objectFieldInvalid
+              objectStructure.typeFailureError ||
+              schemaTypeError.objectFieldInvalid
             );
           }
 
@@ -154,8 +188,8 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
           for(let modelProperty in modelInstance) {
             if(!objectStructure.properties[modelProperty]) {
               return reject(
-                objectStructure.customErrorOnTypeFailure ||
-                typeError.objectHasExtraFields
+                objectStructure.typeFailureError ||
+                schemaTypeError.objectHasExtraFields
               );
             }
           }
@@ -172,12 +206,12 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
             return reject(error);
           });
 
-        case kindOfType.union:
+        case kindOfSchema.union:
           // Casting for better inference.
-          const unionStructure = typeStructure as unionStructure;
+          const unionStructure = typeSchema as unionSchema;
 
           return anyPromise(
-            unionStructure.types.map((singleTypeFromUnion: typeStructure) => {
+            unionStructure.types.map((singleTypeFromUnion: typeSchema) => {
               return validModel(singleTypeFromUnion)(modelInstance);
             })
           )
@@ -186,8 +220,8 @@ export const validModel = (typeStructure: typeStructure): ((any) => Promise<void
           })
           .catch((arrayOfRejectedPromisesErrors: any[]) => {
             return reject(
-              unionStructure.customErrorOnTypeFailure ||
-              typeError.unionHasNoMatchingType
+              unionStructure.typeFailureError ||
+              schemaTypeError.unionHasNoMatchingType
             );
           });
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,13 +1,12 @@
-export interface baseType {
-    kindOfType: kindOfType;
-    customErrorOnTypeFailure?: any;
+export interface baseSchema {
+    typeFailureError?: any;
     nullAllowed?: boolean;
     undefinedAllowed?: boolean;
 }
-export interface restrictableType extends baseType {
+export interface restrictableSchema extends baseSchema {
     restriction?: restriction;
 }
-export declare enum kindOfType {
+export declare enum kindOfSchema {
     primitive = 0,
     array = 1,
     union = 2,
@@ -22,27 +21,28 @@ export declare enum kindOfPrimitive {
     symbol = 5,
 }
 export declare type restriction = (modelInstance: any) => void | Promise<void>;
-export declare type typeStructure = primitiveStructure | arrayStructure | unionStructure | objectStructure;
-export interface objectStructure extends restrictableType {
+export declare type typeSchema = primitiveSchema | arraySchema | unionSchema | objectSchema;
+export interface objectSchema extends restrictableSchema {
     properties: {
-        [propertyName: string]: typeStructure;
+        [propertyName: string]: typeSchema;
     };
 }
-export interface primitiveStructure extends restrictableType {
+export interface primitiveSchema extends restrictableSchema {
     kindOfPrimitive: kindOfPrimitive;
 }
-export interface arrayStructure extends restrictableType {
-    elementType: typeStructure;
+export interface arraySchema extends restrictableSchema {
+    elementType: typeSchema;
 }
-export interface unionStructure extends baseType {
-    types: typeStructure[];
+export interface unionSchema extends baseSchema {
+    types: typeSchema[];
 }
-export declare enum typeError {
-    nullField = 0,
-    undefinedField = 1,
-    primitiveFieldInvalid = 2,
-    arrayFieldInvalid = 3,
-    objectFieldInvalid = 4,
-    objectHasExtraFields = 5,
-    unionHasNoMatchingType = 6,
+export declare enum schemaTypeError {
+    invalidSchema = 0,
+    nullField = 1,
+    undefinedField = 2,
+    primitiveFieldInvalid = 3,
+    arrayFieldInvalid = 4,
+    objectFieldInvalid = 5,
+    objectHasExtraFields = 6,
+    unionHasNoMatchingType = 7,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface objectSchema extends restrictableSchema {
   /**
    * The properties on the interface.
    */
-  properties: {
+  objectProperties: {
     /**
      * Each property has a type.
      */
@@ -102,7 +102,7 @@ export interface primitiveSchema extends restrictableSchema {
   /**
    * Specifiying which `kindOfPrimitive` it is.
    */
-  kindOfPrimitive: kindOfPrimitive;
+  primitiveType: kindOfPrimitive;
 }
 
 
@@ -111,14 +111,14 @@ export interface primitiveSchema extends restrictableSchema {
  *
  * NOTE: The restriction applies to the array itself, not the elements in
  * the array, the restrictions on the elements themselves will be
- * determined from the restrictions placed on the `elementType`
+ * determined from the restrictions placed on the `arrayElementType`
  * `typeSchema`.
  */
 export interface arraySchema extends restrictableSchema {
   /**
    * The type of a single element in the array.
    */
-  elementType: typeSchema;
+  arrayElementType: typeSchema;
 }
 
 
@@ -130,9 +130,9 @@ export interface arraySchema extends restrictableSchema {
  */
 export interface unionSchema extends baseSchema {
   /**
-   * A union of all the types in `types`.
+   * A union of all the types in `typeSchema`.
    */
-  types: typeSchema[];
+  unionTypes: typeSchema[];
 }
 
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2,15 +2,15 @@
 
 import {
   validModel,
-  arrayStructure,
-  typeStructure,
-  objectStructure,
-  primitiveStructure,
-  unionStructure,
+  arraySchema,
+  typeSchema,
+  objectSchema,
+  primitiveSchema,
+  unionSchema,
   restriction,
   kindOfPrimitive,
-  kindOfType,
-  typeError
+  kindOfSchema,
+  schemaTypeError
 } from "../src/main";
 import {
   mochaAssertPromiseErrorsWith,
@@ -23,25 +23,21 @@ describe("src/main.ts", function() {
 
   describe("#validModel", function() {
 
-    const stringType: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const stringType: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.string
     };
 
     const validString = validModel(stringType);
 
-    const booleanType: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const booleanType: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.boolean
     };
 
-    const numberType: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const numberType: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.number
     };
 
-    const stringAllowingNullOrUndefined: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const stringAllowingNullOrUndefined: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.string,
       nullAllowed: true,
       undefinedAllowed: true
@@ -50,16 +46,14 @@ describe("src/main.ts", function() {
     const validStringOrNullOrUndefined =
       validModel(stringAllowingNullOrUndefined);
 
-    const numberWithCustomError: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const numberWithCustomError: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.number,
-      customErrorOnTypeFailure: "error"
+      typeFailureError: "error"
     };
 
     const validNumberWithCustomError = validModel(numberWithCustomError);
 
-    const booleanWithRestriction: primitiveStructure = {
-      kindOfType: kindOfType.primitive,
+    const booleanWithRestriction: primitiveSchema = {
       kindOfPrimitive: kindOfPrimitive.boolean,
       restriction: (someBool: boolean) => {
         if(someBool) {
@@ -71,8 +65,7 @@ describe("src/main.ts", function() {
     const validBooleanWithRestriction =
       validModel(booleanWithRestriction);
 
-    const basicUserObjectStructure: objectStructure = {
-      kindOfType: kindOfType.object,
+    const basicUserObjectStructure: objectSchema = {
       properties: {
         "email": stringType,
         "password": stringType
@@ -83,8 +76,7 @@ describe("src/main.ts", function() {
     const validBasicUserObjectStructure =
       validModel(basicUserObjectStructure);
 
-    const arrayOfNumberWithCustomErrorAndRestriction: arrayStructure = {
-      kindOfType: kindOfType.array,
+    const arrayOfNumberWithCustomErrorAndRestriction: arraySchema = {
       elementType: numberWithCustomError,
       restriction: (arrayOfNumber: number[]) => {
         if(arrayOfNumber.length > 3) {
@@ -98,16 +90,14 @@ describe("src/main.ts", function() {
 
 
     // Union of 0 types, should always fail.
-    const unionOfNoTypes: unionStructure = {
-      kindOfType: kindOfType.union,
+    const unionOfNoTypes: unionSchema = {
       types: []
     };
 
     const validUnionOfNoTypes =
       validModel(unionOfNoTypes);
 
-    const unionOfPrimitives = {
-      kindOfType: kindOfType.union,
+    const unionOfPrimitives: unionSchema = {
       types: [
         stringType,
         booleanType,
@@ -118,8 +108,7 @@ describe("src/main.ts", function() {
     const validUnionOfPrimitives =
       validModel(unionOfPrimitives);
 
-    const complexObject: objectStructure = {
-      kindOfType: kindOfType.object,
+    const complexObject: objectSchema = {
       properties: {
         "somePrimitive": unionOfPrimitives,
         "arrayOfNumbers": arrayOfNumberWithCustomErrorAndRestriction
@@ -285,7 +274,7 @@ describe("src/main.ts", function() {
       mochaAssertPromiseErrorsWith(
         validUnionOfPrimitives({}),
         (error) => {
-          return error === typeError.unionHasNoMatchingType
+          return error === schemaTypeError.unionHasNoMatchingType
         },
         done
       );

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -24,21 +24,21 @@ describe("src/main.ts", function() {
   describe("#validModel", function() {
 
     const stringType: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.string
+      primitiveType: kindOfPrimitive.string
     };
 
     const validString = validModel(stringType);
 
     const booleanType: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.boolean
+      primitiveType: kindOfPrimitive.boolean
     };
 
     const numberType: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.number
+      primitiveType: kindOfPrimitive.number
     };
 
     const stringAllowingNullOrUndefined: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.string,
+      primitiveType: kindOfPrimitive.string,
       nullAllowed: true,
       undefinedAllowed: true
     };
@@ -47,14 +47,14 @@ describe("src/main.ts", function() {
       validModel(stringAllowingNullOrUndefined);
 
     const numberWithCustomError: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.number,
+      primitiveType: kindOfPrimitive.number,
       typeFailureError: "error"
     };
 
     const validNumberWithCustomError = validModel(numberWithCustomError);
 
     const booleanWithRestriction: primitiveSchema = {
-      kindOfPrimitive: kindOfPrimitive.boolean,
+      primitiveType: kindOfPrimitive.boolean,
       restriction: (someBool: boolean) => {
         if(someBool) {
           return Promise.reject("error");
@@ -66,7 +66,7 @@ describe("src/main.ts", function() {
       validModel(booleanWithRestriction);
 
     const basicUserObjectStructure: objectSchema = {
-      properties: {
+      objectProperties: {
         "email": stringType,
         "password": stringType
       },
@@ -77,7 +77,7 @@ describe("src/main.ts", function() {
       validModel(basicUserObjectStructure);
 
     const arrayOfNumberWithCustomErrorAndRestriction: arraySchema = {
-      elementType: numberWithCustomError,
+      arrayElementType: numberWithCustomError,
       restriction: (arrayOfNumber: number[]) => {
         if(arrayOfNumber.length > 3) {
           return Promise.reject("restriction-error");
@@ -91,14 +91,14 @@ describe("src/main.ts", function() {
 
     // Union of 0 types, should always fail.
     const unionOfNoTypes: unionSchema = {
-      types: []
+      unionTypes: []
     };
 
     const validUnionOfNoTypes =
       validModel(unionOfNoTypes);
 
     const unionOfPrimitives: unionSchema = {
-      types: [
+      unionTypes: [
         stringType,
         booleanType,
         numberType
@@ -109,7 +109,7 @@ describe("src/main.ts", function() {
       validModel(unionOfPrimitives);
 
     const complexObject: objectSchema = {
-      properties: {
+      objectProperties: {
         "somePrimitive": unionOfPrimitives,
         "arrayOfNumbers": arrayOfNumberWithCustomErrorAndRestriction
       }

--- a/website/src/TypescriptTypeParser.elm
+++ b/website/src/TypescriptTypeParser.elm
@@ -435,7 +435,7 @@ typeStructureToKleen ts =
                         let
                             primitiveStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "kindOfPrimitive: " <> (F.premap primitiveTypeToString F.string) <> newLine)
+                                    <> (indent1 <> F.s "primitiveType: " <> (F.premap primitiveTypeToString F.string) <> newLine)
                                     <> (indent0 <> F.s "}")
 
                             primitiveTypeToString primitiveType =
@@ -455,7 +455,7 @@ typeStructureToKleen ts =
                         let
                             objectStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "properties: {" <> newLine)
+                                    <> (indent1 <> F.s "objectProperties: {" <> newLine)
                                     <> (F.premap objectPropertiesToString F.string <> newLine)
                                     <> (indent1 <> F.s "}" <> newLine)
                                     <> (indent0 <> F.s "}")
@@ -485,7 +485,7 @@ typeStructureToKleen ts =
 
                             arrayStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "elementType: " <> F.premap (printStructure <| tabLevel + 1) F.string <> newLine)
+                                    <> (indent1 <> F.s "arrayElementType: " <> F.premap (printStructure <| tabLevel + 1) F.string <> newLine)
                                     <> (indent0 <> F.s "}")
                         in
                             F.print arrayStructurePrinter typeStructure
@@ -501,7 +501,7 @@ typeStructureToKleen ts =
 
                             unionStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "types: [" <> newLine)
+                                    <> (indent1 <> F.s "unionTypes: [" <> newLine)
                                     <> (F.premap typeStructureContentsToString F.string)
                                     <> (indent1 <> F.s "]" <> newLine)
                                     <> (indent0 <> F.s "}")

--- a/website/src/TypescriptTypeParser.elm
+++ b/website/src/TypescriptTypeParser.elm
@@ -435,7 +435,6 @@ typeStructureToKleen ts =
                         let
                             primitiveStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "kindOfType: kleen.kindOfType.primitive," <> newLine)
                                     <> (indent1 <> F.s "kindOfPrimitive: " <> (F.premap primitiveTypeToString F.string) <> newLine)
                                     <> (indent0 <> F.s "}")
 
@@ -456,7 +455,6 @@ typeStructureToKleen ts =
                         let
                             objectStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "kindOfType: kleen.kindOfType.object," <> newLine)
                                     <> (indent1 <> F.s "properties: {" <> newLine)
                                     <> (F.premap objectPropertiesToString F.string <> newLine)
                                     <> (indent1 <> F.s "}" <> newLine)
@@ -487,7 +485,6 @@ typeStructureToKleen ts =
 
                             arrayStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "kindOfType: kleen.kindOfType.array," <> newLine)
                                     <> (indent1 <> F.s "elementType: " <> F.premap (printStructure <| tabLevel + 1) F.string <> newLine)
                                     <> (indent0 <> F.s "}")
                         in
@@ -504,7 +501,6 @@ typeStructureToKleen ts =
 
                             unionStructurePrinter =
                                 (F.s "{" <> newLine)
-                                    <> (indent1 <> F.s "kindOfType: kleen.kindOfType.union" <> newLine)
                                     <> (indent1 <> F.s "types: [" <> newLine)
                                     <> (F.premap typeStructureContentsToString F.string)
                                     <> (indent1 <> F.s "]" <> newLine)


### PR DESCRIPTION
- Syntax no longer requires user to specify `kindOfType`
- Syntax updated to be a bit more clear because kindOfType is no longer specified
  - Eg. `elementType` to `arrayElementType`

- Tests updated
- Generator AST -> Schema updated to reflect new syntax
- Use word "schema" instead of "type" to avoid "type types", a bit more clear naming.
- Closes #5 