### PR TITLE
add anySchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "typings": "lib/main.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./bin/test.sh"
   },
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   unionSchema,
   referenceSchema,
   primitiveSchema,
+  anySchema,
   restriction,
   schemaTypeError,
   referenceAcc
@@ -78,33 +79,38 @@ const getTypeOfSchema = (typeSchema: typeSchema) => {
   const isUnion = !isUndefined((typeSchema as unionSchema).unionTypes);
   const isReference = !isUndefined((typeSchema as referenceSchema).referenceName);
   const isMap = !isUndefined((typeSchema as mapSchema).mapValueType);
+  const isAny = (typeSchema as anySchema).isAny;
 
   const kindOfTypeSchema =
-    (isObject && !isArray && !isPrimitive && !isUnion && !isReference && !isMap)
+    (isObject && !isArray && !isPrimitive && !isUnion && !isReference && !isMap && !isAny)
       ?
         kindOfSchema.object
       :
-        (!isObject && isArray && !isPrimitive && !isUnion && !isReference && !isMap)
+        (!isObject && isArray && !isPrimitive && !isUnion && !isReference && !isMap && !isAny)
           ?
             kindOfSchema.array
           :
-            (!isObject && !isArray && isPrimitive && !isUnion && !isReference && !isMap)
+            (!isObject && !isArray && isPrimitive && !isUnion && !isReference && !isMap && !isAny)
               ?
                 kindOfSchema.primitive
               :
-                (!isObject && !isArray && !isPrimitive && isUnion && !isReference && !isMap)
+                (!isObject && !isArray && !isPrimitive && isUnion && !isReference && !isMap && !isAny)
                   ?
                     kindOfSchema.union
                   :
-                    (!isObject && !isArray && !isPrimitive && !isUnion && isReference && !isMap)
+                    (!isObject && !isArray && !isPrimitive && !isUnion && isReference && !isMap && !isAny)
                     ?
                       kindOfSchema.reference
                     :
-                      (!isObject && !isArray && !isPrimitive && !isUnion && !isReference && isMap)
+                      (!isObject && !isArray && !isPrimitive && !isUnion && !isReference && isMap && !isAny)
                       ?
                         kindOfSchema.map
                       :
-                        null;
+                        (!isObject && !isArray && !isPrimitive && !isUnion && !isReference && !isMap && isAny)
+                        ?
+                          kindOfSchema.any
+                        :
+                          null;
 
   return kindOfTypeSchema;
 }
@@ -382,6 +388,13 @@ const validModelInternal = (typeSchema: typeSchema
             validModelInternal(referenceActualTypeSchema, references)(modelInstance)
           );
         }
+
+        case kindOfSchema.any: {
+          // Cast for better inference.
+          const anyStructure = typeSchema as anySchema;
+          return resolveIfRestrictionMet(anyStructure.restriction);
+        }
+            
       }
     });
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ export declare enum kindOfSchema {
     object = 3,
     reference = 4,
     map = 5,
+    any = 6,
 }
 export declare enum kindOfPrimitive {
     string = 0,
@@ -30,7 +31,7 @@ export declare enum kindOfPrimitive {
     symbol = 5,
 }
 export declare type restriction = (modelInstance: any) => void | Promise<void>;
-export declare type typeSchema = primitiveSchema | arraySchema | unionSchema | objectSchema | referenceSchema | mapSchema;
+export declare type typeSchema = primitiveSchema | arraySchema | unionSchema | objectSchema | referenceSchema | mapSchema | anySchema;
 export interface referenceSchema extends baseSchema, restrictable {
     referenceName: string;
 }
@@ -50,6 +51,9 @@ export interface unionSchema extends baseSchema {
 }
 export interface mapSchema extends baseSchema, restrictable, nameable {
     mapValueType: typeSchema;
+}
+export interface anySchema extends baseSchema, restrictable, nameable {
+    isAny: boolean;
 }
 export declare enum schemaTypeError {
     invalidSchema = 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,8 @@ export enum kindOfSchema {
   union,
   object,
   reference,
-  map
+  map,
+  any
 }
 
 
@@ -97,7 +98,8 @@ export type typeSchema
   | unionSchema
   | objectSchema
   | referenceSchema
-  | mapSchema;
+  | mapSchema
+  | anySchema;
 
 
 /**
@@ -202,6 +204,15 @@ export interface mapSchema extends baseSchema, restrictable, nameable {
   mapValueType: typeSchema;
 }
 
+
+/**
+* An 'any' schema is similar to the 'any' type in typescript. It is used to
+* validate models against any type of data. Used for cases where we only
+* care about the restrictions.
+*/
+export interface anySchema extends baseSchema, restrictable, nameable {
+  isAny: boolean;
+}
 
 /**
  * Possible errors thrown by the type being invalid.


### PR DESCRIPTION
### Closes

Closes #22

### Description

Adds the `any` schema. This trivial schema only verifies the data model against restrictions (allows all types) and can be used to verify data type using third party methods such as a verifier method on a class.